### PR TITLE
update README.md with new compiling instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,11 @@ retro-gtk depends on the following libraries at compile time and at run time:
 ## Compiling
 
 To configure the compilation, do:
-`./autogen.sh`
+`meson build`
 
 You can specify the installation prefix by doing:
-`./autogen.sh --prefix /my/prefix`
-
-Then compile:
-`./configure`
-`make`
+`meson build --prefix /my/prefix`
 
 ## Installing
 
-`make install`
+`ninja -C build install`


### PR DESCRIPTION
Hello,
When I tryed to build retro-gtk I saw the compiling instructions changed since the last modifications of README.md.
So I removed the "autotools" paragraph and added  "meson" and "ninja" instructions instead.
br